### PR TITLE
Fix clip source creation for local and bundled videos

### DIFF
--- a/2playertimer.html
+++ b/2playertimer.html
@@ -1057,8 +1057,6 @@
 
     const getClipSource = (clip) => {
       if (!clip) return '';
-      if (clip.file) {
-        const url = URL.createObjectURL(clip.file);
       if (clip.cachedUrl) return clip.cachedUrl;
       if (clip.file) {
         const url = URL.createObjectURL(clip.file);


### PR DESCRIPTION
## Summary
- ensure clip URLs are cached once to avoid leaks while loading local selections
- keep fallback clip loading ready from the bundled clips directory

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c7f2dfaa4832e919dde9a424bb64e)