### PR TITLE
Fix start panel grid and theme header

### DIFF
--- a/2playertimer.html
+++ b/2playertimer.html
@@ -339,7 +339,7 @@
     .quadrant.choose-phase .chooseTint{opacity:1; pointer-events: auto;}
     .choose-layout{display:grid; grid-template-rows: var(--video-fr)fr var(--panel-fr)fr; width:100%; height:100%;}
     .choose-video-area{display:flex; flex-direction:column; align-items:center; justify-content:center; gap:.5rem; padding:.5rem;}
-    .choose-panel-area{display:flex; flex-direction:column; align-items:center; justify-content:center; gap:.6rem; padding:.5rem; text-align:center;}
+    .choose-panel-area{display:flex; flex-direction:column; align-items:center; justify-content:center; gap:.75rem; padding:1rem; text-align:center;}
     .choose-actions{display:flex; gap:.6rem; flex-wrap:wrap; justify-content:center;}
     .chooseTitle{font-weight:900; font-size:clamp(1.2rem, 4vw, 2.4rem); letter-spacing:.02em; margin-bottom:.35rem}
     .theme-name{font-size:clamp(2rem, 6vw, 3rem); font-weight:900; letter-spacing:.05em;}
@@ -351,6 +351,9 @@
     .choose-grid-item video { width:100%; height:100%; object-fit:cover; display:block; }
     .choose-grid-item .item-label { position:absolute; bottom:0; left:0; right:0; background:linear-gradient(180deg, transparent, rgba(0,0,0,.65)); padding:.45rem .65rem; font-weight:800; text-transform:uppercase; font-size:.9rem; letter-spacing:.05em; color:var(--themeText); text-shadow:0 2px 8px rgba(0,0,0,.6); }
     .choose-grid-item.active { border-color: var(--themeAccent); box-shadow:0 0 0 3px color-mix(in srgb, var(--themeAccent) 50%, transparent); }
+    .start-theme-title { font-size: clamp(2.5rem, 7vw, 4rem); font-weight: 900; letter-spacing: .06em; text-transform: uppercase; margin: 0; text-shadow: 0 6px 20px rgba(0,0,0,.35); }
+    .start-controls { display: flex; flex-direction: column; align-items: center; gap: .5rem; }
+    .start-controls .btn-player-start { width: 100%; max-width: 280px; }
     .vibe-preview { display:flex; flex-direction:column; align-items:center; gap:.25rem; padding:.9rem 1.1rem; border-radius:.85rem; background:linear-gradient(145deg, color-mix(in srgb, var(--themeBase) 85%, #000 15%), color-mix(in srgb, var(--themeDark) 70%, #000 30%)); min-width:260px; border:1px solid color-mix(in srgb, var(--themeAccent) 60%, transparent); box-shadow:0 12px 26px rgba(0,0,0,.35); }
     .vibe-preview .preview-panel { width:100%; padding:.75rem; border-radius:.65rem; border:1px solid color-mix(in srgb, var(--themeAccent) 55%, transparent); text-align:center; font-weight:850; letter-spacing:.05em; color:var(--themeText); box-shadow:0 8px 18px rgba(0,0,0,.35); }
     .vibe-preview .preview-title { font-size:1rem; letter-spacing:.08em; opacity:.9; text-transform:uppercase; color:var(--themeText); }
@@ -470,7 +473,7 @@
     <div class="choose-layout">
       <div class="choose-video-area">
         <div class="chooseTitle">PICK A VIDEO</div>
-        <div class="choose-grid">
+        <div class="choose-grid start-grid">
           <div class="choose-grid-item" data-idx="0"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
           <div class="choose-grid-item" data-idx="1"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
           <div class="choose-grid-item" data-idx="2"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
@@ -478,33 +481,18 @@
         </div>
       </div>
       <div class="choose-panel-area">
-        <div class="theme-name"></div>
+        <div class="theme-name start-theme-title"></div>
+        <div class="choose-actions start-controls">
+          <button class="btn-change-theme">Change Theme</button>
+          <button class="btn-player-start" style="pointer-events:auto; cursor:pointer; font-size:1.4rem; padding:.9rem 2.2rem; border-radius:.8rem; background:#44ff44; color:black; border:3px solid white; font-weight:900;">START</button>
+        </div>
         <div class="vibe-preview">
           <div class="preview-title">VIBE PREVIEW</div>
           <div class="preview-panel preview-panel-info">Info panel</div>
           <div class="preview-panel preview-panel-video">Video label</div>
         </div>
-        <div class="choose-actions">
-          <button class="btn-change-theme">Switch Theme</button>
-          <button class="btn-player-start" style="pointer-events:auto; cursor:pointer; font-size:1.4rem; padding:.9rem 2.2rem; border-radius:.8rem; background:#44ff44; color:black; border:3px solid white; font-weight:900;">START</button>
-        </div>
       </div>
     </div>
-    <div class="chooseTitle">CHOOSE THEME</div>
-    <div class="theme-name" style="font-size:1.5rem; margin:.5rem 0; font-weight:700;"></div>
-    <div class="choose-grid">
-      <div class="choose-grid-item" data-idx="0"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-      <div class="choose-grid-item" data-idx="1"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-      <div class="choose-grid-item" data-idx="2"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-      <div class="choose-grid-item" data-idx="3"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-    </div>
-    <div class="vibe-preview">
-      <div class="preview-title">VIBE PREVIEW</div>
-      <div class="preview-panel preview-panel-info">Info panel</div>
-      <div class="preview-panel preview-panel-video">Video label</div>
-    </div>
-    <button class="btn-change-theme" style="margin-bottom:.5rem;">Change Theme</button>
-    <button class="btn-player-start" style="pointer-events:auto; cursor:pointer; font-size:2rem; padding:1rem 3rem; border-radius:.8rem; background:#44ff44; color:black; border:3px solid white; font-weight:900;">START</button>
   </div>
 </div>
 
@@ -588,7 +576,7 @@
     <div class="choose-layout">
       <div class="choose-video-area">
         <div class="chooseTitle">PICK A VIDEO</div>
-        <div class="choose-grid">
+        <div class="choose-grid start-grid">
           <div class="choose-grid-item" data-idx="0"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
           <div class="choose-grid-item" data-idx="1"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
           <div class="choose-grid-item" data-idx="2"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
@@ -596,33 +584,18 @@
         </div>
       </div>
       <div class="choose-panel-area">
-        <div class="theme-name"></div>
+        <div class="theme-name start-theme-title"></div>
+        <div class="choose-actions start-controls">
+          <button class="btn-change-theme">Change Theme</button>
+          <button class="btn-player-start" style="pointer-events:auto; cursor:pointer; font-size:1.4rem; padding:.9rem 2.2rem; border-radius:.8rem; background:#44ff44; color:black; border:3px solid white; font-weight:900;">START</button>
+        </div>
         <div class="vibe-preview">
           <div class="preview-title">VIBE PREVIEW</div>
           <div class="preview-panel preview-panel-info">Info panel</div>
           <div class="preview-panel preview-panel-video">Video label</div>
         </div>
-        <div class="choose-actions">
-          <button class="btn-change-theme">Switch Theme</button>
-          <button class="btn-player-start" style="pointer-events:auto; cursor:pointer; font-size:1.4rem; padding:.9rem 2.2rem; border-radius:.8rem; background:#44ff44; color:black; border:3px solid white; font-weight:900;">START</button>
-        </div>
       </div>
     </div>
-    <div class="chooseTitle">CHOOSE THEME</div>
-    <div class="theme-name" style="font-size:1.5rem; margin:.5rem 0; font-weight:700;"></div>
-    <div class="choose-grid">
-      <div class="choose-grid-item" data-idx="0"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-      <div class="choose-grid-item" data-idx="1"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-      <div class="choose-grid-item" data-idx="2"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-      <div class="choose-grid-item" data-idx="3"><video playsinline muted preload="metadata"></video><div class="item-label"></div></div>
-    </div>
-    <div class="vibe-preview">
-      <div class="preview-title">VIBE PREVIEW</div>
-      <div class="preview-panel preview-panel-info">Info panel</div>
-      <div class="preview-panel preview-panel-video">Video label</div>
-    </div>
-    <button class="btn-change-theme" style="margin-bottom:.5rem;">Change Theme</button>
-    <button class="btn-player-start" style="pointer-events:auto; cursor:pointer; font-size:2rem; padding:1rem 3rem; border-radius:.8rem; background:#44ff44; color:black; border:3px solid white; font-weight:900;">START</button>
   </div>
 </div>
 </div>
@@ -1281,8 +1254,9 @@
           peace: rootEl.querySelector('.video-container .overlay[data-type="peace"]'), 
         },
         chooseTint: rootEl.querySelector('.chooseTint'),
-        chooseGrid: rootEl.querySelector('.chooseTint .choose-grid'),
-        chooseGridItems: rootEl.querySelectorAll('.chooseTint .choose-grid-item'),
+        chooseGrid: rootEl.querySelector('.chooseTint .start-grid'),
+        chooseGridItems: rootEl.querySelectorAll('.chooseTint .start-grid .choose-grid-item'),
+        startThemeTitle: rootEl.querySelector('.chooseTint .start-theme-title'),
         vibePreview: rootEl.querySelector('.chooseTint .vibe-preview'),
         vibePreviewInfo: rootEl.querySelector('.chooseTint .preview-panel-info'),
         vibePreviewVideo: rootEl.querySelector('.chooseTint .preview-panel-video'),
@@ -2398,12 +2372,9 @@
         const themeName = chooseTint.querySelector('.theme-name');
 
         const renderStartGrid = () => {
-          const shuffled = [...videos];
-          for (let i = shuffled.length - 1; i > 0; i--) {
-            const j = Math.floor(Math.random() * (i + 1));
-            [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+          if (!startPool.length) {
+            startPool = videos.slice(0, Math.min(4, videos.length));
           }
-          startPool = shuffled.slice(0, Math.min(4, shuffled.length));
           if (!q.selectedStartClip && startPool.length) {
             const pickIdx = Math.min(q.id, startPool.length - 1);
             q.selectedStartClip = startPool[pickIdx];
@@ -2469,6 +2440,20 @@
           chooseTint.style.background = `linear-gradient(120deg, ${pal.base}66, ${pal.accent}66)`;
           themeName.textContent = q.vibe.name.toUpperCase();
           themeName.style.color = pal.accent;
+          if (q.startThemeTitle) {
+            q.startThemeTitle.textContent = q.vibe.name.toUpperCase();
+            q.startThemeTitle.style.color = pal.accent;
+            q.startThemeTitle.style.fontFamily = font.family;
+            q.startThemeTitle.style.textTransform = font.transform;
+            q.startThemeTitle.style.textShadow = `0 8px 28px ${pal.accent}55`;
+          }
+          chooseTint.querySelectorAll('.btn-change-theme, .btn-player-start').forEach(btn => {
+            btn.style.background = `color-mix(in srgb, ${pal.accent} 70%, ${pal.base} 30%)`;
+            btn.style.borderColor = `${pal.accent}aa`;
+            btn.style.color = q.vibe.text || '#f8fbff';
+            btn.style.textTransform = font.transform;
+            btn.style.fontFamily = font.family;
+          });
 
           const textColor = q.vibe.text || '#f8fbff';
           q.el.style.setProperty('--themeBase', pal.base);


### PR DESCRIPTION
## Summary
- restructure the start overlay to show a 2x2 start grid within the video area and keep the selected clip stable
- add a themed info panel with an XXL theme title plus change-theme/start controls styled from the active theme
- keep initial playback using the chosen clip and avoid cycling the start options while waiting to start

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ca2637904832eac86fb9a8c40adf1)