### PR TITLE
Fix default two-player timer video source

### DIFF
--- a/2playertimer.html
+++ b/2playertimer.html
@@ -504,7 +504,7 @@
   <div class="stage">
     <div class="quadrant" id="q1">
       <div class="video-container">
-        <video class="quad-video" src="clips/aurora.mp4" loop muted></video>
+        <video playsinline webkit-playsinline preload="metadata" class="quad-video" src="clips/5sx22FHuckole59.mp4" loop muted></video>
         <div class="vibe-overlay"></div>
         <div class="event-overlay" data-effect="light" style="background: radial-gradient(circle at 50% 50%, rgba(255,140,0,.6), rgba(0,0,0,.75)); mix-blend-mode: screen;"></div>
         <div class="event-overlay" data-effect="smoke" style="background: radial-gradient(circle at 50% 50%, rgba(200,200,200,.55), rgba(0,0,0,.8));"></div>
@@ -560,7 +560,7 @@
 
     <div class="quadrant" id="q2">
       <div class="video-container">
-        <video class="quad-video" src="clips/aurora.mp4" loop muted></video>
+        <video playsinline webkit-playsinline preload="metadata" class="quad-video" src="clips/5sx22FHuckole59.mp4" loop muted></video>
         <div class="vibe-overlay"></div>
         <div class="event-overlay" data-effect="light" style="background: radial-gradient(circle at 50% 50%, rgba(255,140,0,.6), rgba(0,0,0,.75)); mix-blend-mode: screen;"></div>
         <div class="event-overlay" data-effect="smoke" style="background: radial-gradient(circle at 50% 50%, rgba(200,200,200,.55), rgba(0,0,0,.8));"></div>


### PR DESCRIPTION
## Summary
- point the two-player timer quadrant videos to a clip that exists in the repository so playback succeeds
- add inline/mobile-friendly playback attributes to the default quadrant videos so they preload metadata reliably

## Testing
- python -m unittest discover


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cbd831074832e941977eaa836ea38)